### PR TITLE
Add test to NPM scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.3.0",
   "description": "Decorator for binding method to an object",
   "main": "lib/index.js",
+  "scripts": {
+    "test": "make test"
+  },
   "author": "Andrey Popp <8mayday@gmail.com>",
   "license": "MIT",
   "devDependencies": {


### PR DESCRIPTION
This might be a dumb idea because you do everything via Makefile.

However I haven't found Makefiles to be common in NPM ecosystem so I'd suggest adding at least support for “blessed” `npm test` (it even has its own command!) just to point people like me to look at the Makefile.