### PR TITLE
Fix property overriding itself when accessed on the prototype

### DIFF
--- a/src/__tests__/autobind-test.js
+++ b/src/__tests__/autobind-test.js
@@ -100,6 +100,14 @@ describe('autobind class decorator', function() {
     });
   });
 
+  it('does not override itself when accessed on the prototype', function() {
+    A.prototype.getValue;
+
+    let a = new A();
+    let getValue = a.getValue;
+    assert(getValue() === 42);
+  })
+
   describe('with Reflect', function () {
     describe('with Symbols', function () {
       it('binds methods with symbol keys', function () {

--- a/src/index.js
+++ b/src/index.js
@@ -68,6 +68,10 @@ function boundMethod(target, key, descriptor) {
   return {
     configurable: true,
     get() {
+      if (this === target.prototype) {
+        return fn;
+      }
+
       let boundFn = fn.bind(this);
       Object.defineProperty(this, key, {
         value: boundFn,


### PR DESCRIPTION
The function would rewrite itself when it was accessed from the `prototype`. Specifically, I noticed this when testing autobind-decorator in the soon-to-be-released update to React Hot Loader. The method version worked, but the class version broke because `if (typeof prototype.render === 'function')` check inside React Hot Loader caused `render` to get bound to the `prototype`.