### PR TITLE
Fix property overriding, while calling 'super'

### DIFF
--- a/src/__tests__/autobind-test.js
+++ b/src/__tests__/autobind-test.js
@@ -56,6 +56,23 @@ describe('autobind method decorator', function() {
       }
     }, /@autobind decorator can only be applied to methods/);
   });
+
+
+  it('should not override binded instance method, while calling super method with the same name', function() {
+    class B extends A {
+
+      @autobind
+      getValue() {
+        return super.getValue() + 8;
+      }
+    }
+
+    let b = new B();
+    let value = b.getValue();
+    value = b.getValue();
+
+    assert(value === 50);
+  });
 });
 
 describe('autobind class decorator', function() {

--- a/src/index.js
+++ b/src/index.js
@@ -68,7 +68,7 @@ function boundMethod(target, key, descriptor) {
   return {
     configurable: true,
     get() {
-      if (this === target.prototype) {
+      if (this === target.prototype || this.hasOwnProperty(key)) {
         return fn;
       }
 


### PR DESCRIPTION
In a case, when we need to call parent class method with the same name as existing property, current autobind-decorator implementation overrides instance method with parent method.