### PR TITLE
Update copywrite, move to its own line

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
-/**
- * @copyright 2015, Andrey Popp <8mayday@gmail.com>
+// @copyright 2016, Andrey Popp <8mayday@gmail.com>
+
+/*
  *
  * The decorator may be used on classes or methods
  * ```


### PR DESCRIPTION
Updated the copyright to 2016, also moved it to its own line so that consumers preserving copyrights can easily trip out the rest of the comments in production.