### PR TITLE
Supports filtering which methods are bound

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 A class or method decorator which binds methods to the instance
 so `this` is always correct, even when the method is detached.
 
-This is particularly useful for situations like React components, where 
-you often pass methods as event handlers and would otherwise need to 
+This is particularly useful for situations like React components, where
+you often pass methods as event handlers and would otherwise need to
 `.bind(this)`.
 ```
 Before:
@@ -18,8 +18,8 @@ As decorators are a part of future ES2016 standard they can only be used with
 transpilers such as [Babel](http://babeljs.io).
 
 **Note Babel 6 users:**
-The implementation of the decorator transform is currently on hold as the syntax 
-is not final. If you would like to use this project with Babel 6.0, you may use 
+The implementation of the decorator transform is currently on hold as the syntax
+is not final. If you would like to use this project with Babel 6.0, you may use
 [babel-plugin-transform-decorators-legacy](https://github.com/loganfsmyth/babel-plugin-transform-decorators-legacy)
 which implement Babel 5 decorator transform for Babel 6.
 
@@ -52,3 +52,22 @@ Example:
 
     @autobind
     class Component { }
+
+    // If you only want to bind certain methods, use the matching mode
+
+    @autobind(/^(handle)/)
+    class Component {
+      // Bound to instance
+      handleClick(e) {}
+
+      // Not bound to instnace
+      render() {}
+    }
+
+    // You can invert the matching by passing `true` as the second argument.
+
+    @autobind(/^(render)/, true)
+    class Component {
+      // Not bound to instance.
+      render() {}
+    }

--- a/src/__tests__/autobind-test.js
+++ b/src/__tests__/autobind-test.js
@@ -235,7 +235,7 @@ describe('autobind class decorator with matching', function() {
     assert(getValue() === 42);
   });
 
-  it('skips bind on unmatched mathods', function() {
+  it('skips bind on unmatched methods', function() {
     assert.throws(() => {
       let a = new A();
       let fetchValue = a.fetchValue;

--- a/src/__tests__/autobind-test.js
+++ b/src/__tests__/autobind-test.js
@@ -210,3 +210,69 @@ describe('autobind class decorator', function() {
     });
   });
 });
+
+describe('autobind class decorator with matching', function() {
+
+  @autobind(/^(getValue)$/)
+  class A {
+
+    constructor() {
+      this.value = 42;
+    }
+
+    getValue() {
+      return this.value;
+    }
+
+    fetchValue() {
+      return this.value;
+    }
+  }
+
+  it('binds matched method to an instance', function() {
+    let a = new A();
+    let getValue = a.getValue;
+    assert(getValue() === 42);
+  });
+
+  it('skips bind on unmatched mathods', function() {
+    assert.throws(() => {
+      let a = new A();
+      let fetchValue = a.fetchValue;
+      fetchValue();
+    })
+  });
+});
+
+describe('autobind class decorator with inverse matching', function() {
+
+  @autobind(/^(fetchValue)$/, true)
+  class A {
+
+    constructor() {
+      this.value = 42;
+    }
+
+    getValue() {
+      return this.value;
+    }
+
+    fetchValue() {
+      return this.value;
+    }
+  }
+
+  it('binds matched method to an instance', function() {
+    let a = new A();
+    let getValue = a.getValue;
+    assert(getValue() === 42);
+  });
+
+  it('skips bind on unmatched methods', function() {
+    assert.throws(() => {
+      let a = new A();
+      let fetchValue = a.fetchValue;
+      fetchValue();
+    })
+  });
+});


### PR DESCRIPTION
Solves #20 and can help avoid some collisions with React tooling. For example, I'm having issues with the getters colliding with some react babel transforms.

With this, someone could easily publish a `react-autobind-decorator` that would look like the following:

```js
import autobind from 'autobind-decorator'
export default autobind(/^(render)|(shouldComponentUpdate)|(component.*))$/, true)
```

Or you might only want to bind event 'handlers':

```js
@autobind(/^handle/)
class Component {
  // Bound
  handleClick(e) {}

  // Not Bound
  theBusinessLogic() {}
}
```