### PR TITLE
Add setters for bound methods

### DIFF
--- a/src/__tests__/autobind-test.js
+++ b/src/__tests__/autobind-test.js
@@ -73,6 +73,19 @@ describe('autobind method decorator', function() {
 
     assert(value === 50);
   });
+
+  it('add setters for bound methods', function () {
+    assert.doesNotThrow(() => {
+      @autobind
+      class A {
+        doNothing() {}
+      }
+
+      A.prototype.doNothing = function () {
+        return true;
+      };
+    });
+  });
 });
 
 describe('autobind class decorator', function() {

--- a/src/index.js
+++ b/src/index.js
@@ -79,6 +79,11 @@ function boundMethod(target, key, descriptor) {
         writable: true
       });
       return boundFn;
+    },
+    set(value) {
+      Object.defineProperty(this, key, {
+        value: value
+      });
     }
   };
 }


### PR DESCRIPTION
Hello.
I want to use the `@autobind` decorator with this awesome React babel plugin by @gaearon

https://github.com/gaearon/react-transform-catch-errors

But when the page loads I get `Cannot set property render of #<Component> which has only a getter` error in the console.

The fix is to add a setter (see the code).
