### PR TITLE
Upgrade to Babel 6 as well as other things

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -45,7 +45,6 @@
     "no-alert": 2,                    // Disallow the use of alert, confirm, and prompt
     "no-caller": 2,                   // Disallow use of arguments.caller or arguments.callee
     "no-div-regex": 2,                // Disallow division operators explicitly at beginning of regular expression (off by default)
-    "no-empty-label": 2,              // Disallow use of labels for anything other then loops and switches
     "no-eval": 2,                     // Disallow use of eval()
     "no-extend-native": 2,            // Disallow adding to native types
     "no-extra-bind": 2,               // Disallow unnecessary function binding
@@ -125,7 +124,7 @@
     "space-in-brackets": [0, "never"],    // Require or disallow spaces inside brackets (off by default)
     "space-in-parens": [1, "never"],      // Require or disallow spaces inside parentheses (off by default)
     "space-infix-ops": [1, {}],     // Require spaces around operators
-    "space-return-throw-case": [1], // require a space after return, throw, and case
+    "keyword-spacing": [1], // require a space after return, throw, and case
     "space-unary-ops": [1, {"words": true, "nonwords": false}], // Require or disallow spaces before/after unary operators (words on by default, nonwords off by default)
     "spaced-comment": [1, "always"], // Require or disallow a space immediately following the // in a line comment (off by default)
     "wrap-regex": 0,                      // Require regex literals to be wrapped in parentheses (off by default)

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,8 @@ SRC = $(shell find ./src -name '*.js')
 LIB = $(SRC:./src/%=lib/%)
 
 BABEL_OPTS = \
-	--stage 0
+	--presets=es2015 \
+	--plugins=transform-decorators-legacy
 
 build:: $(LIB)
 

--- a/package.json
+++ b/package.json
@@ -13,14 +13,15 @@
   "author": "Andrey Popp <8mayday@gmail.com>",
   "license": "MIT",
   "devDependencies": {
-    "babel": "^5.0.12",
-    "babel-eslint": "^4.0.0",
-    "babelify": "^6.0.2",
-    "core-js": "^0.9.6",
-    "eslint": "^1.0.0",
-    "mocha": "^2.2.4",
-    "mochify": "^2.7.1",
-    "phantomjs": "^1.9.16"
+    "babel-cli": "^6.16.0",
+    "babel-eslint": "^7.0.0",
+    "babel-plugin-transform-decorators-legacy": "^1.3.4",
+    "babel-preset-es2015": "^6.16.0",
+    "babelify": "^7.3.0",
+    "core-js": "^0.9.18",
+    "eslint": "^3.8.0",
+    "mochify": "^2.18.1",
+    "phantomjs": "^2.1.7"
   },
   "repository": {
     "type": "git",

--- a/src/__tests__/.eslintrc
+++ b/src/__tests__/.eslintrc
@@ -53,7 +53,6 @@
     "no-alert": 2,                    // Disallow the use of alert, confirm, and prompt
     "no-caller": 2,                   // Disallow use of arguments.caller or arguments.callee
     "no-div-regex": 2,                // Disallow division operators explicitly at beginning of regular expression (off by default)
-    "no-empty-label": 2,              // Disallow use of labels for anything other then loops and switches
     "no-eval": 2,                     // Disallow use of eval()
     "no-extend-native": 2,            // Disallow adding to native types
     "no-extra-bind": 2,               // Disallow unnecessary function binding
@@ -133,7 +132,7 @@
     "space-in-brackets": [0, "never"],    // Require or disallow spaces inside brackets (off by default)
     "space-in-parens": [1, "never"],      // Require or disallow spaces inside parentheses (off by default)
     "space-infix-ops": [1, {}],     // Require spaces around operators
-    "space-return-throw-case": [1], // require a space after return, throw, and case
+    "keyword-spacing": [1], // require a space after return, throw, and case
     "space-unary-ops": [1, {"words": true, "nonwords": false}], // Require or disallow spaces before/after unary operators (words on by default, nonwords off by default)
     "spaced-comment": [1, "always"], // Require or disallow a space immediately following the // in a line comment (off by default)
     "wrap-regex": 0,                      // Require regex literals to be wrapped in parentheses (off by default)


### PR DESCRIPTION
The main motivation for this is to use Babel 6, which fixes #37, but I went ahead and upgraded most dependencies while I was at it.