### PR TITLE
The autobind doesn't work occasionally

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -74,7 +74,7 @@ function boundMethod(target, key, descriptor) {
     configurable: true,
     get() {
       if (definingProperty || this === target.prototype || this.hasOwnProperty(key)) {
-        return fn;
+        return this.hasOwnProperty(key) ? this[key] : fn;
       }
 
       let boundFn = fn.bind(this);


### PR DESCRIPTION
Hi andreypopp,
  In my react native project, the autobind doesn't work occasionally. I find the root cause is  the origin function would be return when its 'get' has been called twice. 
  I think the bind result should be return in this case.  
  Please help to review this PR. Thanks!