### PR TITLE
fix(core): allow user set new value

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+max_line_length = 120
+
+
+[*.bom.*]
+charset = utf-8-bom
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 lib/
+yarn.lock

--- a/src/__tests__/autobind-test.js
+++ b/src/__tests__/autobind-test.js
@@ -210,3 +210,28 @@ describe('autobind class decorator', function() {
     });
   });
 });
+
+it('should not throw when set new value', function () {
+  class A {
+    constructor() {
+      this.data = 'A';
+    }
+
+    @autobind
+    noop() {
+      return this.data;
+    }
+  }
+
+  const a = new A();
+  a.noop = function noop () {
+    return this.data;
+  };
+  const noop = a.noop;
+  noop();
+  a.noop = function noop2 () {
+    return this.data;
+  };
+  const noop2 = a.noop;
+  noop2();
+});

--- a/src/index.js
+++ b/src/index.js
@@ -72,6 +72,10 @@ function boundMethod(target, key, descriptor) {
 
   return {
     configurable: true,
+    set(value) {
+      fn = value;
+      definingProperty = false;
+    },
     get() {
       if (definingProperty || this === target.prototype || this.hasOwnProperty(key)) {
         return fn;
@@ -80,9 +84,13 @@ function boundMethod(target, key, descriptor) {
       let boundFn = fn.bind(this);
       definingProperty = true;
       Object.defineProperty(this, key, {
-        value: boundFn,
-        configurable: true,
-        writable: true
+        get() {
+          return boundFn;
+        },
+        set(value) {
+          boundFn = value.bind(this);
+        },
+        configurable: true
       });
       definingProperty = false;
       return boundFn;


### PR DESCRIPTION
Allow user to set new value like follow:

```js
class A {
  constructor() {
    this.data = 'A';
  }

  @autobind
  noop() {
    return this.data;
  }
}

const a = new A();
a.noop = function noop () {
  return this.data;
};
const noop = a.noop;
noop();
a.noop = function noop2 () {
  return this.data;
};
const noop2 = a.noop;
noop2();
```

Please note that the new method bind setter/getter to the field, may cause some performance loss.